### PR TITLE
Fixed initialization error in DarwinClientRouteBuilder.clientId

### DIFF
--- a/src/main/java/com/openraildata/DarwinClientRouteBuilder.java
+++ b/src/main/java/com/openraildata/DarwinClientRouteBuilder.java
@@ -29,9 +29,6 @@ import java.net.UnknownHostException;
 @Component
 public class DarwinClientRouteBuilder extends RouteBuilder {
 
-    @Value("${darwinv16.username}")
-    private String username;
-
     @Value("${darwinv16.password}")
     private String password;
 
@@ -46,13 +43,16 @@ public class DarwinClientRouteBuilder extends RouteBuilder {
 
     private final CamelContext camelContext;
     private final DarwinMessageHandler darwinMessageHandler;
+    private String username;
     private final String clientId;
 
 
     public DarwinClientRouteBuilder(CamelContext camelContext,
-                                    DarwinMessageHandler darwinMessageHandler) throws UnknownHostException {
+                                    DarwinMessageHandler darwinMessageHandler,
+                                    @Value("${darwinv16.username}") String username) throws UnknownHostException {
         this.camelContext = camelContext;
         this.darwinMessageHandler = darwinMessageHandler;
+        this.username = username;
         this.clientId = username + "-" + InetAddress.getLocalHost().getCanonicalHostName();
     }
 
@@ -75,3 +75,4 @@ public class DarwinClientRouteBuilder extends RouteBuilder {
     }
 
 }
+


### PR DESCRIPTION
### Problem
In `DarwinClientRouteBuilder`, the `clientId` depends on the `username`, which in turn is a Spring `@Value` taken from `application.properties` and populated with the value corresponding to the property `darwinv16.username`.
Because of how Spring works, the injection of this value can happen after the class has been built. `clientId` however is built in the class' constructor. This leads to the `clientId` being initialized with a `username` that, at the time of class initialization, is still `null`. This means that the `clientId` in turn will be something along the lines of `null-yourHostName`, and since ["if you are `using a Durable Subscriber, your Client ID must begin with your username"`](https://wiki.openraildata.com/index.php?title=Darwin:Push_Port#Real-Time_Update_Data_via_OpenWire_.26_Stomp_Message_Topics), the whole setup of the JMS message listener invoker will fail with:
```
Setup of JMS message listener invoker failed for destination 'darwin.pushport-v16' - trying to recover. Cause: Durable subscription clientId must start with your username
```

### Solution
Make this dependency between the `username` and the `clientId` explicit in the constructor, by promoting `username` as constructor parameter and adding the relative `@Value` annotation before it.